### PR TITLE
chore: Update Go version and dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        go: [ '1.23.4' ]
+        go: [ '1.26' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     name: Lint
     runs-on: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.23.4' ]
+        go: [ '1.26' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     name: Test
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,40 +7,38 @@ jobs:
       matrix:
         go: [ '1.26' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-    name: Lint
-    runs-on: ubuntu-latest
+    name: Lint (${{ matrix.os }}, Go ${{ matrix.go }})
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Lit by go vet
+      - name: Lint by go vet
         run: go vet ./...
 
       - name: Lint by golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
+        uses: golangci/golangci-lint-action@v9
 
   test:
     strategy:
       matrix:
         go: [ '1.26' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-    name: Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }}, Go ${{ matrix.go }})
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Unit tests.
         run: go test -v ./... -coverprofile=coverage.txt

--- a/examples/error_handling/main.go
+++ b/examples/error_handling/main.go
@@ -21,8 +21,7 @@ func main() {
 	// Example of handling different error types
 	_, err = client.FullSync(ctx)
 	if err != nil {
-		var apiErr *zerrors.Error
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := errors.AsType[*zerrors.Error](err); ok {
 			switch apiErr.Code {
 			case zerrors.ErrInvalidToken:
 				log.Printf("Authentication failed: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/nemirlev/zenmoney-go-sdk/v2
 
-go 1.23.4
+go 1.26
 
-require github.com/stretchr/testify v1.10.0
+require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
This pull request updates the Go version and related dependencies across the project, modernizes the CI workflows, and improves error handling in an example. The most important changes are grouped below:

**Build & CI Workflow Updates:**

* Updated the Go version used in the project from `1.23.4` to `1.26` in both `go.mod` and `.github/workflows/test.yml`, ensuring compatibility with the latest language features and improvements. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R5) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L8-R41)
* Upgraded GitHub Actions in `.github/workflows/test.yml` to use newer versions for `setup-go`, `checkout`, and `golangci-lint-action`, improving reliability and security.
* Enhanced the CI matrix to run lint and test jobs on multiple operating systems and display the OS and Go version in the job names for better visibility.

**Dependency Upgrades:**

* Bumped `github.com/stretchr/testify` dependency from `v1.10.0` to `v1.11.1` for improved testing support.

**Code Improvements:**

* Refactored error handling in `examples/error_handling/main.go` to use `errors.AsType` for more idiomatic and type-safe error checks.